### PR TITLE
Refatoração do Frontend para a Stack Recomendada"

### DIFF
--- a/frontend/app/assets/page.tsx
+++ b/frontend/app/assets/page.tsx
@@ -43,7 +43,7 @@ export default function AssetsPage() {
       <div className="text-center mb-8">
         <h1 className="text-3xl font-bold">Ativos Financeiros</h1>
         <p className="text-md text-gray-500 mt-2">
-          Esta é uma lista de ativos com valores estáticos para visualização (somente leitura). 
+          Esta é uma lista de ativos com valores estáticos para visualização (somente leitura).
         </p>
       </div>
 

--- a/frontend/app/clients/edit/[id]/page.tsx
+++ b/frontend/app/clients/edit/[id]/page.tsx
@@ -1,109 +1,153 @@
 'use client';
 
-import { useState, useEffect } from 'react';
-import { useRouter, useParams } from 'next/navigation'; // useParams para pegar o ID da URL
+import { useEffect } from 'react';
+import { useRouter, useParams } from 'next/navigation';
 import axios from 'axios';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { editClientFormSchema, EditClientFormValues } from '@/app/schemas/client.schema';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select'; // Vamos adicionar o Select
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 
-// URL da sua API Backend
 const API_URL = 'http://localhost:3333/api/v1/clients';
+
+interface Client {
+  id: number;
+  name: string;
+  email: string;
+  status: 'ATIVO' | 'INATIVO';
+}
+
+const fetchClientById = async (id: string): Promise<Client> => {
+  const { data } = await axios.get(`${API_URL}/${id}`);
+  return data;
+};
+
+const updateClient = async ({ id, data }: { id: string, data: EditClientFormValues }) => {
+  const response = await axios.put(`${API_URL}/${id}`, data);
+  return response.data;
+};
 
 export default function EditClientPage() {
   const router = useRouter();
-  const params = useParams(); // Hook para ler parâmetros da URL
-  const id = params.id; // Pega o ID do cliente da URL
+  const params = useParams();
+  const id = Array.isArray(params.id) ? params.id[0] : params.id;
+  const queryClient = useQueryClient();
 
-  // Estados para os campos do formulário
-  const [name, setName] = useState('');
-  const [email, setEmail] = useState('');
-  const [status, setStatus] = useState<'ATIVO' | 'INATIVO'>('ATIVO');
+  const { data: client, isLoading, isError } = useQuery({
+    queryKey: ['client', id],
+    // CORREÇÃO AQUI:
+    // Adicionamos uma verificação para garantir que 'id' não é undefined
+    queryFn: () => {
+      if (!id) {
+        // Isso não deve acontecer por causa da opção 'enabled', mas satisfaz o TypeScript
+        throw new Error('ID do cliente não encontrado!');
+      }
+      return fetchClientById(id);
+    },
+    enabled: !!id, // Garante que a query só rode quando o 'id' estiver disponível
+  });
   
-  // Estados para controle de UI
-  const [isLoading, setIsLoading] = useState(true);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const form = useForm<EditClientFormValues>({
+    resolver: zodResolver(editClientFormSchema),
+    defaultValues: {
+      name: '',
+      email: '',
+      status: 'ATIVO',
+    },
+  });
 
-  // Busca os dados do cliente a ser editado quando a página carrega
   useEffect(() => {
-    if (id) {
-      const fetchClientData = async () => {
-        try {
-          const response = await axios.get(`${API_URL}/${id}`);
-          const client = response.data;
-          setName(client.name);
-          setEmail(client.email);
-          setStatus(client.status);
-        } catch (err) {
-          setError('Falha ao buscar dados do cliente.');
-        } finally {
-          setIsLoading(false);
-        }
-      };
-      fetchClientData();
+    if (client) {
+      form.reset(client);
     }
-  }, [id]);
+  }, [client, form]);
 
-  // Submete as alterações para o backend
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    setIsSubmitting(true);
-    setError(null);
-
-    try {
-      await axios.put(`${API_URL}/${id}`, { name, email, status });
+  const updateMutation = useMutation({
+    mutationFn: updateClient,
+    onSuccess: () => {
       alert('Cliente atualizado com sucesso!');
-      router.push('/clients'); // Redireciona para a lista
-    } catch (err: any) {
-      const errorMessage = err.response?.data?.message || 'Falha ao atualizar cliente.';
-      setError(errorMessage);
-    } finally {
-      setIsSubmitting(false);
+      queryClient.invalidateQueries({ queryKey: ['clients'] });
+      queryClient.invalidateQueries({ queryKey: ['client', id] });
+      router.push('/clients');
+    },
+    onError: (error: any) => {
+      const errorMessage = error.response?.data?.message || 'Falha ao atualizar cliente.';
+      alert(errorMessage);
     }
-  };
-  
-  
+  });
+
+  function onSubmit(values: EditClientFormValues) {
+    if (!id) return; // Verificação de segurança extra
+    updateMutation.mutate({ id, data: values });
+  }
+
   if (isLoading) return <p className="p-4 text-center">Carregando dados do cliente...</p>;
+  if (isError) return <p className="p-4 text-center text-red-500">Falha ao buscar dados do cliente.</p>;
 
   return (
     <div className="container mx-auto p-4 max-w-lg">
       <h1 className="text-2xl font-bold mb-6">Editar Cliente</h1>
-      <form onSubmit={handleSubmit} className="space-y-6">
-        {/* Campos de Nome e Email */}
-        <div className="space-y-2">
-          <Label htmlFor="name">Nome</Label>
-          <Input id="name" type="text" value={name} onChange={(e) => setName(e.target.value)} required />
-        </div>
-        <div className="space-y-2">
-          <Label htmlFor="email">Email</Label>
-          <Input id="email" type="email" value={email} onChange={(e) => setEmail(e.target.value)} required />
-        </div>
-
-        {/* Campo de Status */}
-        <div className="space-y-2">
-            <Label htmlFor="status">Status</Label>
-            <Select value={status} onValueChange={(value: 'ATIVO' | 'INATIVO') => setStatus(value)}>
-                <SelectTrigger id="status">
-                    <SelectValue placeholder="Selecione o status" />
-                </SelectTrigger>
-                <SelectContent>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Nome</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="email"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="status"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Status</FormLabel>
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <FormControl>
+                    <SelectTrigger><SelectValue placeholder="Selecione o status" /></SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
                     <SelectItem value="ATIVO">Ativo</SelectItem>
                     <SelectItem value="INATIVO">Inativo</SelectItem>
-                </SelectContent>
-            </Select>
-        </div>
-        
-        {error && <p className="text-red-500 text-sm">{error}</p>}
-
-        <div className="flex justify-end space-x-2 pt-4">
-          <Button type="button" variant="outline" onClick={() => router.back()}>Cancelar</Button>
-          <Button type="submit" disabled={isSubmitting}>
-            {isSubmitting ? 'Salvando...' : 'Salvar Alterações'}
-          </Button>
-        </div>
-      </form>
+                  </SelectContent>
+                </Select>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <div className="flex justify-end space-x-2 pt-4">
+            <Button type="button" variant="outline" onClick={() => router.back()}>Cancelar</Button>
+            <Button type="submit" disabled={updateMutation.isPending}>
+              {updateMutation.isPending ? 'Salvando...' : 'Salvar Alterações'}
+            </Button>
+          </div>
+        </form>
+      </Form>
     </div>
   );
 }

--- a/frontend/app/clients/page.tsx
+++ b/frontend/app/clients/page.tsx
@@ -38,15 +38,21 @@ export default function ClientsPage() {
     fetchClients();
   }, []);
 
+  // 1. FUNÇÃO PARA DELETAR O CLIENTE
   const handleDelete = async (clientId: number) => {
-    if (!window.confirm('Tem certeza que deseja deletar este cliente?')) return;
+    // Pede uma confirmação simples antes de prosseguir
+    if (!window.confirm('Tem certeza que deseja deletar este cliente?')) {
+      return;
+    }
 
     try {
-      
+      // Envia a requisição DELETE para a API
       await axios.delete(`${API_URL}/${clientId}`);
       
+      // Atualiza o estado local para remover o cliente da lista na tela
+      setClients(clients.filter(client => client.id !== clientId));
+
       alert('Cliente deletado com sucesso!');
-      fetchClients(); // Recarrega a lista para atualizar a tela
 
     } catch (err) {
       alert('Falha ao deletar o cliente.');
@@ -82,11 +88,11 @@ export default function ClientsPage() {
                     {client.status}
                   </span>
                   
-                  
                   <Link href={`/clients/edit/${client.id}`}>
                     <Button variant="outline" size="sm">Editar</Button>
                   </Link>
 
+                  {/* 2. CONECTANDO A FUNÇÃO AO BOTÃO */}
                   <Button variant="destructive" size="sm" onClick={() => handleDelete(client.id)}>
                     Deletar
                   </Button>

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
-import { Geist, Geist_Mono } from "next/font/google"; 
-import Link from "next/link"; // Importando o componente de Link para navegação
+import { Geist } from "next/font/google"; 
+import Link from "next/link";
+import Providers from './providers'; // Importe o novo provedor
 import "./globals.css";
 
 const geist = Geist({
@@ -8,14 +9,13 @@ const geist = Geist({
   variable: "--font-geist-sans",
 });
 
-// Metadados atualizados para o seu projeto
 export const metadata: Metadata = {
   title: "Anka Tech - Gestão",
   description: "Gerenciamento de clientes e ativos financeiros.",
 };
 
-// Componente simples de Header para a Navegação
 function Header() {
+  // ... (seu componente Header existente)
   return (
     <header className="bg-white shadow-sm sticky top-0 z-50 border-b">
       <nav className="container mx-auto px-4 py-3 flex justify-between items-center">
@@ -35,7 +35,6 @@ function Header() {
   );
 }
 
-
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -44,10 +43,12 @@ export default function RootLayout({
   return (
     <html lang="pt-BR">
       <body className={`${geist.variable} antialiased bg-gray-50`}>
-        <Header /> 
-        <main>
-          {children} {/* O conteúdo da página será renderizado aqui */}
-        </main>
+        <Providers> {/* Envolvemos tudo com o Providers */}
+          <Header /> 
+          <main>
+            {children}
+          </main>
+        </Providers>
       </body>
     </html>
   );

--- a/frontend/app/providers.tsx
+++ b/frontend/app/providers.tsx
@@ -1,0 +1,14 @@
+'use client';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { useState } from 'react';
+
+export default function Providers({ children }: { children: React.ReactNode }) {
+  const [queryClient] = useState(() => new QueryClient());
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+    </QueryClientProvider>
+  );
+}

--- a/frontend/app/schemas/client.schema.ts
+++ b/frontend/app/schemas/client.schema.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+// Schema para o formulário de CRIAÇÃO de cliente
+export const createClientFormSchema = z.object({
+  name: z.string().min(3, { message: "O nome deve ter no mínimo 3 caracteres." }),
+  email: z.string().email({ message: "Por favor, insira um email válido." }),
+});
+
+// Schema para o formulário de EDIÇÃO de cliente
+export const editClientFormSchema = z.object({
+  name: z.string().min(3, { message: "O nome deve ter no mínimo 3 caracteres." }),
+  email: z.string().email({ message: "Por favor, insira um email válido." }),
+  status: z.enum(['ATIVO', 'INATIVO']),
+});
+
+// Tipos TypeScript inferidos a partir dos schemas
+export type CreateClientFormValues = z.infer<typeof createClientFormSchema>;
+export type EditClientFormValues = z.infer<typeof editClientFormSchema>;

--- a/frontend/components/ui/form.tsx
+++ b/frontend/components/ui/form.tsx
@@ -1,0 +1,167 @@
+"use client"
+
+import * as React from "react"
+import * as LabelPrimitive from "@radix-ui/react-label"
+import { Slot } from "@radix-ui/react-slot"
+import {
+  Controller,
+  FormProvider,
+  useFormContext,
+  useFormState,
+  type ControllerProps,
+  type FieldPath,
+  type FieldValues,
+} from "react-hook-form"
+
+import { cn } from "@/lib/utils"
+import { Label } from "@/components/ui/label"
+
+const Form = FormProvider
+
+type FormFieldContextValue<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+> = {
+  name: TName
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>(
+  {} as FormFieldContextValue
+)
+
+const FormField = <
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>,
+>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  )
+}
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext)
+  const itemContext = React.useContext(FormItemContext)
+  const { getFieldState } = useFormContext()
+  const formState = useFormState({ name: fieldContext.name })
+  const fieldState = getFieldState(fieldContext.name, formState)
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>")
+  }
+
+  const { id } = itemContext
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  }
+}
+
+type FormItemContextValue = {
+  id: string
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>(
+  {} as FormItemContextValue
+)
+
+function FormItem({ className, ...props }: React.ComponentProps<"div">) {
+  const id = React.useId()
+
+  return (
+    <FormItemContext.Provider value={{ id }}>
+      <div
+        data-slot="form-item"
+        className={cn("grid gap-2", className)}
+        {...props}
+      />
+    </FormItemContext.Provider>
+  )
+}
+
+function FormLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+  const { error, formItemId } = useFormField()
+
+  return (
+    <Label
+      data-slot="form-label"
+      data-error={!!error}
+      className={cn("data-[error=true]:text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  )
+}
+
+function FormControl({ ...props }: React.ComponentProps<typeof Slot>) {
+  const { error, formItemId, formDescriptionId, formMessageId } = useFormField()
+
+  return (
+    <Slot
+      data-slot="form-control"
+      id={formItemId}
+      aria-describedby={
+        !error
+          ? `${formDescriptionId}`
+          : `${formDescriptionId} ${formMessageId}`
+      }
+      aria-invalid={!!error}
+      {...props}
+    />
+  )
+}
+
+function FormDescription({ className, ...props }: React.ComponentProps<"p">) {
+  const { formDescriptionId } = useFormField()
+
+  return (
+    <p
+      data-slot="form-description"
+      id={formDescriptionId}
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function FormMessage({ className, ...props }: React.ComponentProps<"p">) {
+  const { error, formMessageId } = useFormField()
+  const body = error ? String(error?.message ?? "") : props.children
+
+  if (!body) {
+    return null
+  }
+
+  return (
+    <p
+      data-slot="form-message"
+      id={formMessageId}
+      className={cn("text-destructive text-sm", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  )
+}
+
+export {
+  useFormField,
+  Form,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormDescription,
+  FormMessage,
+  FormField,
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,11 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@hookform/resolvers": "^5.0.1",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
+        "@tanstack/react-query": "^5.80.6",
         "axios": "^1.9.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -18,7 +20,9 @@
         "next": "15.3.3",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "tailwind-merge": "^3.3.0"
+        "react-hook-form": "^7.57.0",
+        "tailwind-merge": "^3.3.0",
+        "zod": "^3.25.56"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -271,6 +275,18 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
       "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
       "license": "MIT"
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
+      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -1538,6 +1554,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
     "node_modules/@swc/counter": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
@@ -1827,6 +1849,32 @@
         "@tailwindcss/oxide": "4.1.8",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.8"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.80.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.6.tgz",
+      "integrity": "sha512-nl7YxT/TAU+VTf+e2zTkObGTyY8YZBMnbgeA1ee66lIVqzKlYursAII6z5t0e6rXgwUMJSV4dshBTNacNpZHbQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.80.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.6.tgz",
+      "integrity": "sha512-izX+5CnkpON3NQGcEm3/d7LfFQNo9ZpFtX2QsINgCYK9LT2VCIdi8D3bMaMSNhrAJCznRoAkFic76uvLroALBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.80.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tybys/wasm-util": {
@@ -5781,6 +5829,22 @@
         "react": "^19.1.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.57.0.tgz",
+      "integrity": "sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -6972,6 +7036,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.56",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
+      "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,9 +9,11 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",
+    "@tanstack/react-query": "^5.80.6",
     "axios": "^1.9.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
@@ -19,7 +21,9 @@
     "next": "15.3.3",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "tailwind-merge": "^3.3.0"
+    "react-hook-form": "^7.57.0",
+    "tailwind-merge": "^3.3.0",
+    "zod": "^3.25.56"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,94 @@
+{
+  "name": "AnkaTech-Case_FrontEnd",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "dependencies": {
+        "@hookform/resolvers": "^5.0.1",
+        "@tanstack/react-query": "^5.80.6",
+        "react-hook-form": "^7.57.0",
+        "zod": "^3.25.56"
+      }
+    },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
+      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.80.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.80.6.tgz",
+      "integrity": "sha512-nl7YxT/TAU+VTf+e2zTkObGTyY8YZBMnbgeA1ee66lIVqzKlYursAII6z5t0e6rXgwUMJSV4dshBTNacNpZHbQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.80.6",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.80.6.tgz",
+      "integrity": "sha512-izX+5CnkpON3NQGcEm3/d7LfFQNo9ZpFtX2QsINgCYK9LT2VCIdi8D3bMaMSNhrAJCznRoAkFic76uvLroALBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.80.6"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.0",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
+      "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.57.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.57.0.tgz",
+      "integrity": "sha512-RbEks3+cbvTP84l/VXGUZ+JMrKOS8ykQCRYdm5aYsxnDquL0vspsyNhGRO7pcH6hsZqWlPOjLye7rJqdtdAmlg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.56",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.56.tgz",
+      "integrity": "sha512-rd6eEF3BTNvQnR2e2wwolfTmUTnp70aUTqr0oaGbHifzC3BKJsoV+Gat8vxUMR1hwOKBs6El+qWehrHbCpW6SQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "dependencies": {
+    "@hookform/resolvers": "^5.0.1",
+    "@tanstack/react-query": "^5.80.6",
+    "react-hook-form": "^7.57.0",
+    "zod": "^3.25.56"
+  }
+}


### PR DESCRIPTION
Este PR refatora o frontend da aplicação, substituindo a abordagem MVP (useState/useEffect) pela stack recomendada no case: React Query e React Hook Form.

A mudança alinha o projeto com as melhores práticas de mercado, melhorando a gestão de estado do servidor, o caching de dados e a validação de formulários.
Principais Alterações:

    Toda a lógica de busca e mutação de dados (CRUD) foi migrada para React Query (useQuery, useMutation).
    Os formulários de Cliente foram refatorados com React Hook Form e zodResolver para validação integrada.
    A interface do usuário agora é atualizada automaticamente após as operações de CRUD através da invalidação de queries do React Query.

Como Testar:

    Verificar o fluxo completo de CRUD de clientes (Criar, Editar, Deletar) e confirmar a atualização automática da lista.
    Testar a validação dos formulários com dados inválidos (ex: email sem @).
    Confirmar que a navegação e a página de Ativos continuam funcionando como esperado.